### PR TITLE
changing s3 components folder name in readme section

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,11 +35,11 @@ To deploy the solution,
     1. On AWS Console, choose "**S3**" service
     2. Choose your bucket created as mentioned step 3
     3. Press "**Create folder**" button
-    4. Enter "**greengrass-app-component**" in folder name field and press "**Create folder**" button
-    5. Choose the "**greengrass-app-component**" folder and press "**Upload**" button
+    4. Enter "**greengrass-app-components**" in folder name field and press "**Create folder**" button
+    5. Choose the "**greengrass-app-components**" folder and press "**Upload**" button
     6. Press "**Add files**" button on upload screen and choose all the files from greengrass-app-component
     7. Finally, press "**Upload**" button
-    8. Please make sure that all the artifacts are under "**s3://<your bucket name>/greengrass-app-component**". This is very important to ensure that path is correct for successful deployment on edge gateway
+    8. Please make sure that all the artifacts are under "**s3://<your bucket name>/greengrass-app-components**". This is very important to ensure that path is correct for successful deployment on edge gateway
 
 
 #### Deployment

--- a/cfn/certificate.template
+++ b/cfn/certificate.template
@@ -75,7 +75,7 @@ Resources:
     Properties:
       Count: 1
       Handle: !Ref IoTCertificateWaitHandle
-      Timeout: "60"
+      Timeout: "300"
 
   IoTCertificateSecret:
     Type: AWS::SecretsManager::Secret


### PR DESCRIPTION
Issue: CloudFormation Stack - CREATE_FAILED

*Description of changes:*
**1.1:**
Prerequisites: create a folder in S3 under the name greengrass-app-component:
CloudFormation Template using:
URI: s3://${ArtefactsBucketName}/greengrass-app-components/monitor_wastebin_app.py\n\

**1.2:** The following resource(s) failed to create: [IoTCertificateWaitCondition].
Reason: WaitCondition timed out. Received 0 conditions when expecting 1
Solution: Increased to 300 sec timeout value


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
